### PR TITLE
del + faster

### DIFF
--- a/src/globby.nim
+++ b/src/globby.nim
@@ -138,8 +138,7 @@ proc del*[T](tree: GlobTree[T], glob: string) =
     globParts = glob.split('/').globSimplify()
     i = 0
   while i < tree.data.len:
-    var entry = tree.data[i]
-    if entry.parts.globMatch(globParts):
+    if tree.data[i].parts.globMatch(globParts):
       tree.data.delete(i)
       continue
     inc i

--- a/tests/benchmark.nim
+++ b/tests/benchmark.nim
@@ -80,3 +80,6 @@ timeIt "findAll ../*/..", 10000:
   for path in tree.findAll(glob):
     inc count
   doAssert count > 0
+
+timeIt "del", 10000:
+  tree.del(paths[rand(0..paths.high)])


### PR DESCRIPTION
before:
`del ................................ 0.000 ms      0.009 ms    ±0.018  x10000`
after:
`del ................................ 0.000 ms      0.001 ms    ±0.001  x10000`

by not copying entry (assigning to tmp var)